### PR TITLE
Fix itol urls to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The goal is to handle phylogenetic trees in [Newick](https://en.wikipedia.org/wi
 Input files may be local or remote files:
 
 - If file name is of the form `http://<URL>`, the file is download from the given URL.
-- If file name is of the form `itol://<ID>`, the tree having the given ID is downloaded from [iTOL](http://itol.embl.de/) using the iTOL api.
+- If file name is of the form `itol://<ID>`, the tree having the given ID is downloaded from [iTOL](https://itol.embl.de/) using the iTOL api.
 - If file name is of the form `treebase://<ID>`, the tree having the given ID is downloaded from [TreeBase](https://treebase.org).
 - Otherwise, the file is considered local.
 

--- a/cmd/itoldl.go
+++ b/cmd/itoldl.go
@@ -22,7 +22,7 @@ var dlitolCmd = &cobra.Command{
 
 Option -c allows to give a configuration file having tab separated key value pairs, 
 as defined here:
-http://itol.embl.de/help.cgi#bExOpt
+https://itol.embl.de/help.cgi#bExOpt
 `,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		var b []byte

--- a/docs/api/download.md
+++ b/docs/api/download.md
@@ -4,7 +4,7 @@
 
 ### download
 
-#### Download from [iTOL](http://itol.embl.de/) (SVG)
+#### Download from [iTOL](https://itol.embl.de/) (SVG)
 Downloading a tree image from iTOL
 ```go
 package main
@@ -24,7 +24,7 @@ func main() {
 	var b []byte
 	var err error
 
-	// See http://itol.embl.de/help.cgi#bExOpt for all config options
+	// See https://itol.embl.de/help.cgi#bExOpt for all config options
 	config = make(map[string]string)
 	config["display_mode"] = "3"          // Unrooted
 	config["ignore_branch_length"] = "0"  // Take branch length into account
@@ -42,7 +42,7 @@ func main() {
 }
 ```
 
-#### Download from [iTOL](http://itol.embl.de/) (Newick format)
+#### Download from [iTOL](https://itol.embl.de/) (Newick format)
 Downloading a tree image from iTOL
 ```go
 package main

--- a/docs/api/upload.md
+++ b/docs/api/upload.md
@@ -4,7 +4,7 @@
 
 ### upload
 
-#### Upload a tree to [iTOL](http://itol.embl.de/)
+#### Upload a tree to [iTOL](https://itol.embl.de/)
 
 	
 ```go

--- a/docs/commands/download.md
+++ b/docs/commands/download.md
@@ -4,7 +4,7 @@
 
 ### download
 This command downloads trees or tree images from a given source. Two subcommands so far:
-* `gotree download itol`, which downloads a tree file/image from [iTOL](http://itol.embl.de/), given a tree id (`-i`) and a configuration file (`-c`). Formats may be "png", "eps", "svg", "pdf", "newick", "nexus", "phyloxml". The configuration file (used only with image formats) is a tab separated key/value file corresponding to the iTOL [api optional parameters](http://itol.embl.de/help.cgi#bExOpt).
+* `gotree download itol`, which downloads a tree file/image from [iTOL](https://itol.embl.de/), given a tree id (`-i`) and a configuration file (`-c`). Formats may be "png", "eps", "svg", "pdf", "newick", "nexus", "phyloxml". The configuration file (used only with image formats) is a tab separated key/value file corresponding to the iTOL [api optional parameters](https://itol.embl.de/help.cgi#bExOpt).
 * `gotree download ncbitax`, which downloads the ncbi taxonomy from NCBI ftp server and converts it in Newick format. Internal and tip node names are NCBI names given by the file "names.dmp". Please not that to conform to Newick format, following character are replaced by `_` : `()[]:, ;`. Moreover, the NCBI taxononomy may have species (~tips) with children (ex: [taxid:9606](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Tree&id=9606)). These cases are resolved by Gotree by adding a new corresponding tip.
 
 #### Usage

--- a/docs/commands/upload.md
+++ b/docs/commands/upload.md
@@ -9,7 +9,7 @@ iTOL subcommand: It prints the url(s) at which tree(s) is(are) accessible. If `-
 
 If several trees are included in the input file, it will upload all of them, waiting 1 second between each upload to avoid overload of iTOL server.
 
-It is possible to give itol annotation files (see [iTOL documentation](http://itol.embl.de/help.cgi#annot)) to the uploader at the end of command line:
+It is possible to give itol annotation files (see [iTOL documentation](https://itol.embl.de/help.cgi#annot)) to the uploader at the end of command line:
 ```
 gotree upload itol -i tree.nw --name tree --user-id uploadkey --project project annotation*.txt
 ```

--- a/download/itol.go
+++ b/download/itol.go
@@ -17,7 +17,7 @@ func NewItolImageDownloader(config map[string]string) *ItolImageDownloader {
 
 // Down a tree image from ITOL
 func (d *ItolImageDownloader) Download(id string, format int) ([]byte, error) {
-	posturl := "http://itol.embl.de/batch_downloader.cgi"
+	posturl := "https://itol.embl.de/batch_downloader.cgi"
 	var err error
 	var postresponse *http.Response
 	var responsebody []byte


### PR DESCRIPTION
Some of the batch endpoints seem to have broken behavior now when using http instead of https.